### PR TITLE
[FEAT] NAVER API를 통한 뉴스 기사 제공

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,6 +1525,17 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -4644,6 +4655,14 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
       "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/src/api/naver.js
+++ b/src/api/naver.js
@@ -1,0 +1,11 @@
+import naxios from '@/utils/axios-naver.js'
+
+function searchNews(param, success, fail) {
+	naxios.get(`/v1/search/news.json?query=${param}`)
+	.then(success)
+	.catch(fail)
+}
+
+export {
+	searchNews
+}

--- a/src/components/HouseNewsList.vue
+++ b/src/components/HouseNewsList.vue
@@ -1,0 +1,48 @@
+<script setup>
+
+</script>
+
+<template>
+	<div id="news-list">
+      <div class="middle-title">📢 부동산 뉴스</div>
+      <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
+        <div class="carousel-inner">
+          <div class="carousel-item active">
+            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
+          </div>
+          <div class="carousel-item">
+            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
+          </div>
+          <div class="carousel-item">
+            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
+          </div>
+        </div>
+        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Next</span>
+        </button>
+      </div>
+    </div>
+</template>
+
+<style scoped>
+
+#news-list {
+  width: 372px; height: 250px;
+  margin-top: 24px;
+  margin-left: 24px;
+}
+
+#news-list .middle-title {
+
+  margin-bottom: 12px;
+
+  font-size: 20px;
+  font-weight: bold;
+}
+
+</style>

--- a/src/components/HouseNewsList.vue
+++ b/src/components/HouseNewsList.vue
@@ -1,8 +1,41 @@
 <script setup>
 
+import { ref } from 'vue';
+
 function go(url) {
   window.open(url, "_blank");
 }
+
+function convertDate(pubDate) {
+  const splitDate = pubDate.split(' ')
+  return splitDate[3] + ". " + splitDate[2] + ". " + splitDate[1] + ". " + splitDate[0];
+}
+
+convertDate("Tue, 21 May 2024 15:33:00 +0900")
+
+const newsList = ref([
+  {
+    "title": "이창희 대표 &quot;기본·균형 갖춘 투자 명가로 도약할 것&quot;",
+    "originallink": "https://www.hankyung.com/article/2024052119741",
+    "link": "https://n.news.naver.com/mnews/article/015/0004987158?sid=101",
+    "description": "이 대표는 “<b>부동산</b> 경기 침체로 대체투자에 대한 관심이 감소했지만, 여전히 유망한 분야”라며 “사업 확장을 위해 에쿼티 투자, 부실채권(NPL) 펀드 등 다양한 투자 전략을 모색 중”이라고 말했다.",
+    "pubDate": "Tue, 21 May 2024 15:33:00 +0900"
+  },
+  {
+    "title": "금융당국, 상호금융 건전성 관리 고삐…거액여신한도 제도화",
+    "originallink": "https://www.mediapen.com/news/view/921192",
+    "link": "https://www.mediapen.com/news/view/921192",
+    "description": "<b>부동산</b> 경기가 회복되지 않는 가운데 프로젝트파이낸싱(PF)과 유사한 성격의 관리형 토지신탁이나 공동대출... 또 외형이 지역 내 상업금융기관 이상인 조합이 늘어나고 <b>부동산</b> PF, 공동대출 등 새로운 영업 형태가... ",
+    "pubDate": "Tue, 21 May 2024 15:32:00 +0900"
+  },
+  {
+    "title": "다올자산운용은, 글로벌 펀드 열풍 주도…시장 변동성에 민첩한 대응",
+    "originallink": "https://www.hankyung.com/article/2024052119761",
+    "link": "https://n.news.naver.com/mnews/article/015/0004987156?sid=101",
+    "description": "주식과 채권 같은 전통자산부터 국내외 <b>부동산</b>, 선박, 인프라 등 대체투자에도 적극적으로 나서고 있다. 이를 바탕으로 지속적인 성장을 이어오고 있다. 다올자산운용은 그동안 다양한 국내외 인기 상품을 선보였다.... ",
+    "pubDate": "Tue, 21 May 2024 15:32:00 +0900"
+  }
+])
 
 </script>
 
@@ -12,11 +45,11 @@ function go(url) {
       <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
         <div class="carousel-inner">
           
-          <div class="carousel-item active">
-            <div class="card-news" @click="go('https://www.google.com')">
-              <div class="news-title">“<b>분양</b>가 더 오르기 전 선점해야” ‘원주 푸르지오 더 센트럴’ 21일부터 정...</div>
-              <div class="news-description">최근 각종 PF대출 시장의 경색과 <b>분양</b>가 상승 전망도 당장 <b>분양</b>하는 새 아파트 관심도를 높이는 요소입니다. 최근 주택건설 사업비 조달 핵심이던 <b>부동산</b> 프로젝트파이낸싱(PF)이 각종 부실 이유로 막힌데다 기존 PF대출...</div>
-              <div class="news-date">2024. May. 21. Tue,</div>
+          <div class="carousel-item active" v-for="(news) in newsList" :key="news.title">
+            <div class="card-news" @click="go(news.link)">
+              <div class="news-title">{{ news.title }}</div>
+              <div class="news-description">{{ news.description }}</div>
+              <div class="news-date">{{ convertDate(news.pubDate) }}</div>
             </div>
           </div>
 

--- a/src/components/HouseNewsList.vue
+++ b/src/components/HouseNewsList.vue
@@ -1,5 +1,9 @@
 <script setup>
 
+function go(url) {
+  window.open(url, "_blank");
+}
+
 </script>
 
 <template>
@@ -7,15 +11,17 @@
       <div class="middle-title">📢 부동산 뉴스</div>
       <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
         <div class="carousel-inner">
+          
           <div class="carousel-item active">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
+            <div class="card-news" @click="go('https://www.google.com')">
+              <div class="news-title">“<b>분양</b>가 더 오르기 전 선점해야” ‘원주 푸르지오 더 센트럴’ 21일부터 정...</div>
+              <div class="news-description">최근 각종 PF대출 시장의 경색과 <b>분양</b>가 상승 전망도 당장 <b>분양</b>하는 새 아파트 관심도를 높이는 요소입니다. 최근 주택건설 사업비 조달 핵심이던 <b>부동산</b> 프로젝트파이낸싱(PF)이 각종 부실 이유로 막힌데다 기존 PF대출...</div>
+              <div class="news-date">2024. May. 21. Tue,</div>
+            </div>
           </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
+
+          
+
         </div>
         <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
           <span class="carousel-control-prev-icon" aria-hidden="true"></span>
@@ -32,17 +38,55 @@
 <style scoped>
 
 #news-list {
-  width: 372px; height: 250px;
+  width: 372px; height: 100%;
   margin-top: 24px;
   margin-left: 24px;
 }
 
 #news-list .middle-title {
-
-  margin-bottom: 12px;
-
   font-size: 20px;
   font-weight: bold;
 }
+
+#news-list .card-news {
+
+  height: 100%;
+
+  margin: 12px;
+  /* border-radius: 8px; */
+  cursor: pointer;
+
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+
+}
+
+.news-date {
+  text-align: right;  
+  font-size: small; font-weight: bold;
+
+  margin: 8px;
+}
+
+.news-title {
+  width: 100%;
+
+  padding: 8px;
+
+  font-size: 14px;
+  font-weight: bold;
+
+  background-color: rgb(218, 218, 218);
+  /* border-radius: 8px 8px 0 0; */
+}
+
+.news-description {
+  margin: 8px;
+
+  font-size: 12px;
+
+  color: rgb(119, 119, 119);
+}
+
+
 
 </style>

--- a/src/utils/axios-naver.js
+++ b/src/utils/axios-naver.js
@@ -1,0 +1,12 @@
+import naxios from 'axios';
+
+const { VITE_X_NAVER_CLIENT_ID, VITE_X_NAVER_CLIENT_SECRET } = import.meta.env;
+
+export default naxios.create({
+	baseURL: 'https://openapi.naver.com',
+	headers: {
+		"Content-Type": "application/json",
+		"X-Naver-Client-Id": VITE_X_NAVER_CLIENT_ID,
+		"X-Naver-Client-Secret": VITE_X_NAVER_CLIENT_SECRET
+	}
+})

--- a/src/views/NavigationAllView.vue
+++ b/src/views/NavigationAllView.vue
@@ -3,6 +3,7 @@
 import { useHouseStore } from '@/stores/counter.js';
 import HouseSimple from '@/components/HouseSimple.vue';
 import NavigationDivision from "@/components/NavigationDivision.vue";
+import HouseNewsList from '@/components/HouseNewsList.vue';
 
 const houseStore = useHouseStore();
 
@@ -32,31 +33,8 @@ const houseStore = useHouseStore();
 
 	<NavigationDivision/>
 
-	<!-- 공지사항 -->
-	<div id="announcement">
-      <div class="middle-title">📢 공지사항</div>
-      <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
-        <div class="carousel-inner">
-          <div class="carousel-item active">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-        </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Next</span>
-        </button>
-      </div>
-    </div>
+  <!-- 부동산 뉴스 -->
+	<HouseNewsList/>
 
 </template>
 
@@ -120,20 +98,6 @@ const houseStore = useHouseStore();
   background-color: #e0e0e0;
   border-radius: 10px;
   box-shadow: inset 0px 0px 5px white;
-}
-
-#announcement {
-  width: 372px; height: 250px;
-  margin-top: 24px;
-  margin-left: 24px;
-}
-
-#announcement .middle-title {
-
-  margin-bottom: 12px;
-
-  font-size: 20px;
-  font-weight: bold;
 }
 
 </style>

--- a/src/views/NavigationAptView.vue
+++ b/src/views/NavigationAptView.vue
@@ -3,6 +3,7 @@
 import { useHouseStore } from '@/stores/counter.js';
 import HouseSimple from '@/components/HouseSimple.vue';
 import NavigationDivision from "@/components/NavigationDivision.vue";
+import HouseNewsList from '@/components/HouseNewsList.vue';
 
 const houseStore = useHouseStore();
 
@@ -31,31 +32,8 @@ const houseStore = useHouseStore();
 
 	<NavigationDivision/>
 
-	<!-- 공지사항 -->
-	<div id="announcement">
-      <div class="middle-title">📢 공지사항</div>
-      <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
-        <div class="carousel-inner">
-          <div class="carousel-item active">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-        </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Next</span>
-        </button>
-      </div>
-    </div>
+	<!-- 부동산 뉴스 -->
+	<HouseNewsList/>
 
 </template>
 
@@ -119,20 +97,6 @@ const houseStore = useHouseStore();
   background-color: #e0e0e0;
   border-radius: 10px;
   box-shadow: inset 0px 0px 5px white;
-}
-
-#announcement {
-  width: 372px; height: 250px;
-  margin-top: 24px;
-  margin-left: 24px;
-}
-
-#announcement .middle-title {
-
-  margin-bottom: 12px;
-
-  font-size: 20px;
-  font-weight: bold;
 }
 
 </style>

--- a/src/views/NavigationOfficetelView.vue
+++ b/src/views/NavigationOfficetelView.vue
@@ -3,6 +3,7 @@
 import { useHouseStore } from '@/stores/counter.js';
 import HouseSimple from '@/components/HouseSimple.vue';
 import NavigationDivision from "@/components/NavigationDivision.vue";
+import HouseNewsList from '@/components/HouseNewsList.vue';
 
 const houseStore = useHouseStore();
 
@@ -31,31 +32,8 @@ const houseStore = useHouseStore();
 
 	<NavigationDivision/>
 
-	<!-- 공지사항 -->
-	<div id="announcement">
-      <div class="middle-title">📢 공지사항</div>
-      <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
-        <div class="carousel-inner">
-          <div class="carousel-item active">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-        </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Next</span>
-        </button>
-      </div>
-    </div>
+	<!-- 부동산 뉴스 -->
+	<HouseNewsList/>
 
 </template>
 
@@ -119,20 +97,6 @@ const houseStore = useHouseStore();
   background-color: #e0e0e0;
   border-radius: 10px;
   box-shadow: inset 0px 0px 5px white;
-}
-
-#announcement {
-  width: 372px; height: 250px;
-  margin-top: 24px;
-  margin-left: 24px;
-}
-
-#announcement .middle-title {
-
-  margin-bottom: 12px;
-
-  font-size: 20px;
-  font-weight: bold;
 }
 
 </style>

--- a/src/views/NavigationVillaView.vue
+++ b/src/views/NavigationVillaView.vue
@@ -3,6 +3,7 @@
 import { useHouseStore } from '@/stores/counter.js';
 import HouseSimple from '@/components/HouseSimple.vue';
 import NavigationDivision from "@/components/NavigationDivision.vue";
+import HouseNewsList from '@/components/HouseNewsList.vue';
 
 const houseStore = useHouseStore();
 
@@ -31,31 +32,8 @@ const houseStore = useHouseStore();
 
 	<NavigationDivision/>
 
-	<!-- 공지사항 -->
-	<div id="announcement">
-      <div class="middle-title">📢 공지사항</div>
-      <div id="carouselExampleAutoplaying" class="carousel slide" data-bs-ride="carousel">
-        <div class="carousel-inner">
-          <div class="carousel-item active">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-          <div class="carousel-item">
-            <img src="https://picsum.photos/380/200" class="d-block w-100" alt="...">
-          </div>
-        </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleAutoplaying" data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Next</span>
-        </button>
-      </div>
-    </div>
+	<!-- 부동산 뉴스 -->
+	<HouseNewsList/>
 	
 </template>
 
@@ -119,20 +97,6 @@ const houseStore = useHouseStore();
   background-color: #e0e0e0;
   border-radius: 10px;
   box-shadow: inset 0px 0px 5px white;
-}
-
-#announcement {
-  width: 372px; height: 250px;
-  margin-top: 24px;
-  margin-left: 24px;
-}
-
-#announcement .middle-title {
-
-  margin-bottom: 12px;
-
-  font-size: 20px;
-  font-weight: bold;
 }
 
 </style>


### PR DESCRIPTION
# ✏️ Description
> [뉴스 검색 API 레퍼런스](https://developers.naver.com/docs/serviceapi/search/news/news.md#%EB%89%B4%EC%8A%A4)

1. 네이버에서 제공하는 뉴스 검색 API를 활용하여 `부동산 분양`을 키워드로 데이터를 조회한다.
2. 해당 데이터를 카드 형식의 UI를 통해 사용자에게 제공한다.

# 🛠 Features
- [ ] 뉴스 정보를 보여줄 카드 UI 개발
- [ ] NAVER에서 제공하는 뉴스 검색 API 레퍼런스를 참고하여 데이터 조회 및 데이터 뿌리기
